### PR TITLE
Changed redis.get to redis.setnx

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -76,7 +76,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
   end
 
   def sid_collision?(sid)
-    !!redis.setnx(prefixed(sid), nil).tap do |value| # rubocop: disable DoubleNegation
+    !!redis.setnx(prefixed(sid), nil).tap do |value| # rubocop: disable DoubleNegation, LineLength
       on_sid_collision.call(sid) if value && on_sid_collision
     end
   end

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -249,7 +249,7 @@ describe RedisSessionStore do
 
     context 'when destroyed via #destroy_session' do
       it 'deletes the prefixed key from redis' do
-        redis = double('redis', get: nil)
+        redis = double('redis', setnx: false)
         store.stub(redis: redis)
         sid = store.send(:generate_sid)
         expect(redis).to receive(:del).with("#{options[:key_prefix]}#{sid}")


### PR DESCRIPTION
Changed redis.get to redis.setnx, in order to instead of looking if the key exists try to set it up without any data and avoid the **unlikely** raise condition of somebody else asking for the same key.
