### PR TITLE
Setting key in sid_collision? method

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -71,11 +71,11 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
   def generate_sid
     loop do
       sid = super
-      break sid unless sid_collision?(sid)
+      break sid unless claim_sid_unless_collision(sid)
     end
   end
 
-  def sid_collision?(sid)
+  def claim_sid_unless_collision(sid)
     !!redis.get(prefixed(sid)).tap do |value| # rubocop: disable DoubleNegation
       redis.setnx(prefixed(sid), nil) if value.nil?
       on_sid_collision.call(sid) if value && on_sid_collision

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -280,7 +280,7 @@ describe RedisSessionStore do
       end
 
       it 'passes the colliding sid to the collision handler' do
-        store.send(:sid_collision?, 'whatever')
+        store.send(:claim_sid_unless_collision, 'whatever')
         expect(@sid).to eql('whatever')
       end
     end


### PR DESCRIPTION
Putting back setex in 'set_session' and added setnx in 'sid_collision?' when 'get' returns nil,  it means that it is available
