### PR TITLE
Fix undefined constant error

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -11,5 +11,6 @@ Redis Session Store authors
 - Justin McNally
 - Mathias Meyer
 - Michael Fields
+- Michael Xavier
 - Olek Poplavsky
 - Tim Lossen

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -5,6 +5,10 @@ require 'redis'
 # the MemCacheStore code, simply dropping in Redis instead.
 class RedisSessionStore < ActionDispatch::Session::AbstractStore
   VERSION = '0.6.5'
+  # Rails 3.1 and beyond defines the constant elsewhere
+  unless defined?(ENV_SESSION_OPTIONS_KEY)
+    ENV_SESSION_OPTIONS_KEY = Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY
+  end
 
   # ==== Options
   # * +:key+ - Same as with the other cookie stores, key name

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -1,7 +1,17 @@
 # vim:fileencoding=utf-8
 
+unless defined?(Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY)
+  module Rack # rubocop:disable Documentation
+    module Session
+      module Abstract # rubocop:disable Documentation
+        ENV_SESSION_OPTIONS_KEY = 'rack.session.options'.freeze
+      end
+    end
+  end
+end
+
 unless defined?(ActionDispatch::Session::AbstractStore)
-  module ActionDispatch
+  module ActionDispatch # rubocop:disable Documentation
     module Session
       class AbstractStore # rubocop:disable Documentation
         ENV_SESSION_OPTIONS_KEY = 'rack.session.options'.freeze


### PR DESCRIPTION
Evidently this case is never hit as middleware because options is always specified, but if it is not, that constant is undefined.
