### PR TITLE
Add missing ActionPack dependency

### DIFF
--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
                 .match(/^  VERSION = '(.*)'/)[1]
 
   gem.add_runtime_dependency 'redis'
+  gem.add_runtime_dependency 'actionpack', '>= 3', '< 5'
 
   gem.add_development_dependency 'fakeredis'
   gem.add_development_dependency 'rake'


### PR DESCRIPTION
The gem depends on ActionPack, but didn't state that explicitly.

Btw, you'd do well to mention some minimum required version of the `redis` gem in the the `gemspec`.
