### PR TITLE
Option for custom Redis object to interface with storage

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -18,7 +18,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
   #   * +:db+ - Database number, defaults to 0.
   #   * +:key_prefix+ - Prefix for keys used in Redis, e.g. +myapp:+
   #   * +:expire_after+ - A number in seconds for session timeout
-  #   * +:redis_object+ - Connect to Redis with given object rather than create one
+  #   * +:client+ - Connect to Redis with given object rather than create one
   # * +:on_redis_down:+ - Called with err, env, and SID on Errno::ECONNREFUSED
   # * +:on_session_load_error:+ - Called with err and SID on Marshal.load fail
   # * +:serializer:+ - Serializer to use on session data, default is :marshal.
@@ -45,7 +45,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
 
     @default_options.merge!(namespace: 'rack:session')
     @default_options.merge!(redis_options)
-    @redis = redis_options[:redis_object] || Redis.new(redis_options)
+    @redis = redis_options[:client] || Redis.new(redis_options)
     @on_redis_down = options[:on_redis_down]
     @serializer = determine_serializer(options[:serializer])
     @on_session_load_error = options[:on_session_load_error]

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -104,21 +104,21 @@ describe RedisSessionStore do
         key: random_string,
         secret: random_string,
         redis: {
-          redis_object: redis_object,
+          client: redis_client,
           key_prefix: 'myapp:session:',
           expire_after: 60 * 30
         }
       }
     end
 
-    let(:redis_object) { double('redis_object') }
+    let(:redis_client) { double('redis_client') }
 
     it 'assigns given redis object to @redis' do
-      store.instance_variable_get(:@redis).should be(redis_object)
+      store.instance_variable_get(:@redis).should be(redis_client)
     end
 
-    it 'assigns the :redis_object option to @default_options' do
-      default_options[:redis_object].should be(redis_object)
+    it 'assigns the :client option to @default_options' do
+      default_options[:client].should be(redis_client)
     end
 
     it 'assigns the :key_prefix option to @default_options' do


### PR DESCRIPTION
This adds a feature to allow use of an alternate Redis object to interface with storage, rather than creating one.

Rationale: At my company we have a custom Redis sub-class that transparently handles some Redis communication failures and fail-over of the master Redis database to another server. This could also allow use of other back ends that provide a Redis-like interface in Ruby.
