### PR TITLE
Support options with string keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,7 @@ language: ruby
 rvm:
 - ree
 - 1.8.7
+- 1.9.3
+- 2.0.0
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
 - ree
 - 1.8.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 language: ruby
 rvm:
 - ree
-- 1.9.3
-- 2.0.0
+- 1.8.7
 notifications:
   email: false

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,6 +3,7 @@ Redis Session Store authors
 
 - Ben Marini
 - Dan Buch
+- Daniel Alejandro Gaytán Valencia
 - Donald Plummer
 - Edwin Cruz
 - Gonçalo Silva

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,5 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in redis-session-store.gemspec
 gemspec
 
-gem 'activesupport', '1.0.0'
 gem 'rake', :group => :test
 gem 'minitest', :group => :test, :platform => :ruby_18

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,6 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in redis-session-store.gemspec
 gemspec
 
+gem 'activesupport', '1.0.0'
 gem 'rake', :group => :test
 gem 'minitest', :group => :test, :platform => :ruby_18

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -19,8 +19,10 @@ class RedisSessionStore < ActionController::Session::AbstractStore
   def initialize(app, options = {})
     super
 
-    options = options.with_indifferent_access
-    redis_options = (options[:redis] || {}).with_indifferent_access
+    options = options.symbolize_keys
+    options[:redis] = options[:redis].symbolize_keys if options[:redis]
+
+    redis_options = options[:redis] || {}
 
     @default_options.merge!(:namespace => 'rack:session')
     @default_options.merge!(redis_options)

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -1,5 +1,4 @@
 require 'redis'
-require 'active_support/core_ext'
 
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
@@ -19,8 +18,8 @@ class RedisSessionStore < ActionController::Session::AbstractStore
   def initialize(app, options = {})
     super
 
-    options = options.symbolize_keys
-    options[:redis] = options[:redis].symbolize_keys if options[:redis]
+    options = symbolize_keys(options)
+    options[:redis] = symbolize_keys(options[:redis]) if options[:redis]
 
     redis_options = options[:redis] || {}
 
@@ -30,6 +29,14 @@ class RedisSessionStore < ActionController::Session::AbstractStore
   end
 
   private
+
+    def symbolize_keys(hash)
+      hash.inject({}) do |options, (key, value)|
+        options[(key.to_sym rescue key) || key] = value
+        options
+      end
+    end
+
     def prefixed(sid)
       "#{@default_options[:key_prefix]}#{sid}"
     end

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -1,4 +1,5 @@
 require 'redis'
+require 'active_support/core_ext'
 
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
@@ -18,7 +19,8 @@ class RedisSessionStore < ActionController::Session::AbstractStore
   def initialize(app, options = {})
     super
 
-    redis_options = options[:redis] || {}
+    options = options.with_indifferent_access
+    redis_options = (options[:redis] || {}).with_indifferent_access
 
     @default_options.merge!(:namespace => 'rack:session')
     @default_options.merge!(redis_options)

--- a/test/redis_session_store_test.rb
+++ b/test/redis_session_store_test.rb
@@ -63,6 +63,46 @@ describe RedisSessionStore do
     end
   end
 
+  describe 'when initializing with the redis sub-hash options with string keys' do
+    def options
+      {
+        'key' => random_string,
+        'secret' => random_string,
+        'redis' => {
+          'host' => 'hosty.local',
+          'port' => 16379,
+          'db' => 2,
+          'key_prefix' => 'myapp:session:',
+          'expire_after' => 60 * 120
+        }
+      }
+    end
+
+    it 'creates a redis instance' do
+      store.instance_variable_get(:@redis).wont_equal nil
+    end
+
+    it 'assigns the :host option to @default_options' do
+      default_options[:host].must_equal 'hosty.local'
+    end
+
+    it 'assigns the :port option to @default_options' do
+      default_options[:port].must_equal 16379
+    end
+
+    it 'assigns the :db option to @default_options' do
+      default_options[:db].must_equal 2
+    end
+
+    it 'assigns the :key_prefix option to @default_options' do
+      default_options[:key_prefix].must_equal 'myapp:session:'
+    end
+
+    it 'assigns the :expire_after option to @default_options' do
+      default_options[:expire_after].must_equal 60 * 120
+    end
+  end
+
   describe 'when initializing with top-level redis options' do
     def options
       {


### PR DESCRIPTION
I load session options in a YAML, so I need to accept strings also as keys.
