### PR TITLE
Change error handling to follow redis-rb gem

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -68,7 +68,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
       value && !value.empty? &&
       redis.exists(prefixed(value))
     )
-  rescue Errno::ECONNREFUSED => e
+  rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
     on_redis_down.call(e, env, value) if on_redis_down
 
     true
@@ -93,7 +93,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
     end
 
     [sid, session]
-  rescue Errno::ECONNREFUSED => e
+  rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
     on_redis_down.call(e, env, sid) if on_redis_down
     [generate_sid, {}]
   end
@@ -121,7 +121,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
       redis.set(prefixed(sid), encode(session_data))
     end
     return sid
-  rescue Errno::ECONNREFUSED => e
+  rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
     on_redis_down.call(e, env, sid) if on_redis_down
     return false
   end
@@ -145,7 +145,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
   def destroy_session_from_sid(sid, options = {})
     redis.del(prefixed(sid))
     (options || {})[:drop] ? nil : generate_sid
-  rescue Errno::ECONNREFUSED => e
+  rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
     on_redis_down.call(e, options[:env] || {}, sid) if on_redis_down
   end
 

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -149,7 +149,7 @@ describe RedisSessionStore do
 
     context 'when unsuccessfully persisting the session' do
       before do
-        allow(store).to receive(:redis).and_raise(Errno::ECONNREFUSED)
+        allow(store).to receive(:redis).and_raise(Redis::CannotConnectError)
       end
 
       it 'returns false' do
@@ -169,7 +169,7 @@ describe RedisSessionStore do
 
     context 'when redis is down' do
       before do
-        allow(store).to receive(:redis).and_raise(Errno::ECONNREFUSED)
+        allow(store).to receive(:redis).and_raise(Redis::CannotConnectError)
         store.on_redis_down = ->(*_a) { @redis_down_handled = true }
       end
 
@@ -189,7 +189,7 @@ describe RedisSessionStore do
         it 'explodes' do
           expect do
             store.send(:set_session, env, session_id, session_data, options)
-          end.to raise_error(Errno::ECONNREFUSED)
+          end.to raise_error(Redis::CannotConnectError)
         end
       end
     end
@@ -243,7 +243,7 @@ describe RedisSessionStore do
 
       context 'when redis is down' do
         it 'returns true (fallback to old behavior)' do
-          allow(store).to receive(:redis).and_raise(Errno::ECONNREFUSED)
+          allow(store).to receive(:redis).and_raise(Redis::CannotConnectError)
           expect(store.send(:session_exists?, :env)).to eq(true)
         end
       end
@@ -270,7 +270,7 @@ describe RedisSessionStore do
 
     context 'when redis is down' do
       before do
-        allow(store).to receive(:redis).and_raise(Errno::ECONNREFUSED)
+        allow(store).to receive(:redis).and_raise(Redis::CannotConnectError)
         allow(store).to receive(:generate_sid).and_return('foop')
       end
 
@@ -290,7 +290,7 @@ describe RedisSessionStore do
         it 'explodes' do
           expect do
             store.send(:get_session, double('env'), fake_key)
-          end.to raise_error(Errno::ECONNREFUSED)
+          end.to raise_error(Redis::CannotConnectError)
         end
       end
     end
@@ -317,7 +317,7 @@ describe RedisSessionStore do
 
       context 'when redis is down' do
         before do
-          allow(store).to receive(:redis).and_raise(Errno::ECONNREFUSED)
+          allow(store).to receive(:redis).and_raise(Redis::CannotConnectError)
         end
 
         it 'returns false' do
@@ -330,7 +330,7 @@ describe RedisSessionStore do
           it 'explodes' do
             expect do
               store.send(:destroy, env)
-            end.to raise_error(Errno::ECONNREFUSED)
+            end.to raise_error(Redis::CannotConnectError)
           end
         end
       end


### PR DESCRIPTION
Previously, errors were being caught using ERRON::ECONNREFUSED, however,
redis-rb never throws that error, instead, it uses the errors outlined
here: https://github.com/redis/redis-rb/blob/master/lib/redis/errors.rb

This commit catches errors according to the errors thrown in redis-rb