### PR TITLE
Make low level session methods public

### DIFF
--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -141,7 +141,7 @@ describe RedisSessionStore do
 
     context 'when successfully persisting the session' do
       it 'returns the session id' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
+        expect(store.set_session(env, session_id, session_data, options))
           .to eq(session_id)
       end
     end
@@ -152,7 +152,7 @@ describe RedisSessionStore do
       end
 
       it 'returns false' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
+        expect(store.set_session(env, session_id, session_data, options))
           .to eq(false)
       end
     end
@@ -161,7 +161,7 @@ describe RedisSessionStore do
       let(:options) { {} }
 
       it 'sets the session value without expiry' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
+        expect(store.set_session(env, session_id, session_data, options))
           .to eq(session_id)
       end
     end
@@ -173,12 +173,12 @@ describe RedisSessionStore do
       end
 
       it 'returns false' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
+        expect(store.set_session(env, session_id, session_data, options))
           .to eq(false)
       end
 
       it 'calls the on_redis_down handler' do
-        store.send(:set_session, env, session_id, session_data, options)
+        store.set_session(env, session_id, session_data, options)
         expect(@redis_down_handled).to eq(true)
       end
 
@@ -187,7 +187,7 @@ describe RedisSessionStore do
 
         it 'explodes' do
           expect do
-            store.send(:set_session, env, session_id, session_data, options)
+            store.set_session(env, session_id, session_data, options)
           end.to raise_error(Redis::CannotConnectError)
         end
       end
@@ -264,7 +264,7 @@ describe RedisSessionStore do
       allow(store).to receive(:generate_sid).and_return(fake_key)
       expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key}")
 
-      store.send(:get_session, double('env'), fake_key)
+      store.get_session(double('env'), fake_key)
     end
 
     context 'when redis is down' do
@@ -274,12 +274,12 @@ describe RedisSessionStore do
       end
 
       it 'returns an empty session hash' do
-        expect(store.send(:get_session, double('env'), fake_key).last)
+        expect(store.get_session(double('env'), fake_key).last)
           .to eq({})
       end
 
       it 'returns a newly generated sid' do
-        expect(store.send(:get_session, double('env'), fake_key).first)
+        expect(store.get_session(double('env'), fake_key).first)
           .to eq('foop')
       end
 
@@ -288,7 +288,7 @@ describe RedisSessionStore do
 
         it 'explodes' do
           expect do
-            store.send(:get_session, double('env'), fake_key)
+            store.get_session(double('env'), fake_key)
           end.to raise_error(Redis::CannotConnectError)
         end
       end
@@ -342,7 +342,7 @@ describe RedisSessionStore do
         sid = store.send(:generate_sid)
         expect(redis).to receive(:del).with("#{options[:key_prefix]}#{sid}")
 
-        store.send(:destroy_session, {}, sid, nil)
+        store.destroy_session({}, sid, nil)
       end
     end
   end
@@ -363,11 +363,11 @@ describe RedisSessionStore do
     shared_examples_for 'serializer' do
       it 'encodes correctly' do
         expect(redis).to receive(:set).with('12345', expected_encoding)
-        store.send(:set_session, env, session_id, session_data, options)
+        store.set_session(env, session_id, session_data, options)
       end
 
       it 'decodes correctly' do
-        expect(store.send(:get_session, env, session_id))
+        expect(store.get_session(env, session_id))
           .to eq([session_id, session_data])
       end
     end
@@ -519,10 +519,10 @@ describe RedisSessionStore do
       sid = 1234
       allow(store).to receive(:redis).and_return(Redis.new)
       data1 = { 'foo' => 'bar' }
-      store.send(:set_session, env, sid, data1)
+      store.set_session(env, sid, data1)
       data2 = { 'baz' => 'wat' }
-      store.send(:set_session, env, sid, data2)
-      _, session = store.send(:get_session, env, sid)
+      store.set_session(env, sid, data2)
+      _, session = store.get_session(env, sid)
       expect(session).to eq(data2)
     end
 
@@ -531,10 +531,10 @@ describe RedisSessionStore do
       sid = 1234
       allow(store).to receive(:redis).and_return(Redis.new)
       data1 = { 'foo' => 'bar' }
-      store.send(:set_session, env, sid, data1)
+      store.set_session(env, sid, data1)
       data2 = { 'baz' => 'wat' }
-      store.send(:set_session, env, sid, data2)
-      _, session = store.send(:get_session, env, sid)
+      store.set_session(env, sid, data2)
+      _, session = store.get_session(env, sid)
       expect(session).to eq(data2)
     end
   end


### PR DESCRIPTION
Recently, while writing some code to access session data at a low level, we ran into an issue with `RedisSessionStore` because it defines the following low level session methods (and aliases) as `private`:

* `#get_session`
* `#find_session`
* `#set_session`
* `#write_session`
* `#destroy_session`
* `#delete_session`

These methods are marked as `private` in the various inheritance trees of `RedisSessionStore` (via `ActionDispatch::Session::AbstractStore`):

* In Rails 4, which uses Rack 1.6, the low level session methods are defined (and marked as private) in  `Rack::Session::Abstract::ID`
* In Rails 5, which uses Rack 2.0 the low level session methods are defined (and marked as private) in `Rack::Session::Abstract::Persisted`.

So at first glance, it seems that `RedisSessionStore` is correct in maintaining the `private` visibility level.

The problem, however, is that the vast majority of real world session store implementations override the parent visibility settings and mark these low level session methods as `public`.

A non exhaustive list of Rack-based session stores in the wild where these methods are _public_, not private:

* `Rack::Session::Abstract::ID` in Rack >2.0 (in https://github.com/rack/rack/blob/2.0.1/lib/rack/session/abstract/id.rb#L414-L431)
* `Rack::Session::Pool` (in https://github.com/rack/rack/blob/master/lib/rack/session/pool.rb#L44-L66)
* `Rack::Session::Memcache` (in https://github.com/rack/rack/blob/master/lib/rack/session/memcache.rb#L49-L76)
* `ActionDispatch::Session::CacheStore` since Rails 3.2 (in https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/session/cache_store.rb#L20-L43)
* `ActionDispatch::Session::MemcacheStore` via `Rack::Session::Dalli`, which it inherits from (in https://github.com/petergoldstein/dalli/blob/v2.7.6/lib/rack/session/dalli.rb#L22-L34 and https://github.com/petergoldstein/dalli/blob/v2.7.6/lib/rack/session/dalli.rb#L43-L71)
* `Rack::Session::Redis`, used by the redis-store gem (in https://github.com/redis-store/redis-rack/blob/master/lib/rack/session/redis.rb#L45-L71)

As a counter example, `ActiveRecordSession` is the one session store I could find in the wild that preserves private visibility for these methods in https://github.com/rails/activerecord-session_store/blob/master/lib/action_dispatch/session/active_record_store.rb#L68-L120)

In short, `RedisSessionStore`'s marking these methods as private, though consistent with its inheritance tree in both recent versions of Rails, is an outlier in the real world of session store implementations, including all of the persistent stores that are bundled with Rails.

The attached PR simply moves the low-level session methods to the public area of the `RedisSessionStore` class definition and adjusts the tests accordingly (i.e. so that they use the now public methods instead of `send`).

In addition to being consistent with other session store APIs in the wild, it's very helpful to be able to have proper access to the low level session store outside the context of a specific request. 😄 