### PR TITLE
Allow Separate Store Session Expiration Option

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,6 +3,7 @@ Redis Session Store authors
 
 - Ben Marini
 - Dan Buch
+- Connor Mullen
 - Donald Plummer
 - Edwin Cruz
 - Gonçalo Silva

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -19,6 +19,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
   #   * +:url+ - Redis url, default is redis://localhost:6379/0
   #   * +:key_prefix+ - Prefix for keys used in Redis, e.g. +myapp:+
   #   * +:expire_after+ - A number in seconds for session timeout
+  #   * +:store_expire_after+ - A number in seconds for stored session timeout. Takes precedence over expire_after and does not effect session cookie expiry.
   #   * +:client+ - Connect to Redis with given object rather than create one
   # * +:on_redis_down:+ - Called with err, env, and SID on Errno::ECONNREFUSED
   # * +:on_session_load_error:+ - Called with err and SID on Marshal.load fail
@@ -115,7 +116,8 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
   end
 
   def set_session(env, sid, session_data, options = nil)
-    expiry = (options || env.fetch(ENV_SESSION_OPTIONS_KEY))[:expire_after]
+    options = options || env.fetch(ENV_SESSION_OPTIONS_KEY)
+    expiry = options[:store_expire_after] || options[:expire_after]
     if expiry
       redis.setex(prefixed(sid), expiry, encode(session_data))
     else


### PR DESCRIPTION
This pull request adds an option that allows you to specify a separate timeout for the expiration of the session in redis than the expiration set on the cookie. This flexibility allows you to use a transient cookie that still expires if the browser is left open. 

I have also added a few specs for the different expiration scenarios.