### PR TITLE
Travis: use jruby-9.1.13.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,18 @@
 inherit_from: .rubocop_todo.yml
 
+AllCops:
+  DisplayCopNames: true
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+Security/MarshalLoad:
+  Enabled: false
+
 FileName:
   Enabled: false
 
 DoubleNegation:
   Enabled: false
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 cache: bundler
 rvm:
 - 2.3.1
-- jruby-9.1.9.0
+- jruby-9.1.12.0
 matrix:
   allow_failures:
-  - rvm: jruby-9.1.9.0
+  - rvm: jruby-9.1.12.0
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 cache: bundler
 rvm:
 - 2.3.1
-- jruby-9.1.12.0
+- jruby-9.1.13.0
 matrix:
   allow_failures:
-  - rvm: jruby-9.1.12.0
+  - rvm: jruby-9.1.13.0
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 cache: bundler
 rvm:
 - 2.3.1
-- jruby-9.1.1.0
+- jruby-9.1.8.0
 matrix:
   allow_failures:
-  - rvm: jruby-9.1.1.0
+  - rvm: jruby-9.1.8.0
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 cache: bundler
 rvm:
 - 2.3.1
-- jruby-9.1.8.0
+- jruby-9.1.9.0
 matrix:
   allow_failures:
-  - rvm: jruby-9.1.8.0
+  - rvm: jruby-9.1.9.0
 notifications:
   email: false
 deploy:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2017/09/06/jruby-9-1-13-0.html

And passes lint.

