### PR TITLE
Add: Oj serializer

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -13,5 +13,6 @@ Redis Session Store authors
 - Michael Fields
 - Michael Xavier
 - Olek Poplavsky
+- Shota Terashita
 - Tim Lossen
 - Todd Bealmear

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ By default the Marshal serializer is used. With Rails 4, you can use JSON as a
 custom serializer:
 
 * `:json` - serialize cookie values with `JSON` (Requires Rails 4+)
+* `:oj` - serialize cookie values with [Oj](https://github.com/ohler55/oj) library (Requires Rails 4+)
 * `:marshal` - serialize cookie values with `Marshal` (Default)
 * `:hybrid` - transparently migrate existing `Marshal` cookie values to `JSON` (Requires Rails 4+)
 * `CustomClass` - You can just pass the constant name of any class that responds to `.load` and `.dump`

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -1,4 +1,5 @@
 require 'redis'
+require 'oj'
 
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
@@ -157,6 +158,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
     case serializer
     when :marshal then Marshal
     when :json    then JsonSerializer
+    when :oj      then OptimizedJsonSerializer
     when :hybrid  then HybridSerializer
     else serializer
     end
@@ -170,6 +172,17 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
 
     def self.dump(value)
       JSON.generate(value, quirks_mode: true)
+    end
+  end
+
+  # Uses fastest JSON library to encode/decode session
+  class OptimizedJsonSerializer
+    def self.load(value)
+      Oj.load(value, quirks_mode: true, mode: :compat)
+    end
+
+    def self.dump(value)
+      Oj.dump(value, quirks_mode: true, mode: :compat)
     end
   end
 

--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |gem|
 
   gem.add_runtime_dependency 'redis', '~> 3'
   gem.add_runtime_dependency 'actionpack', '>= 3', '< 5.1'
+  gem.add_runtime_dependency 'oj', '~> 3'
 
   gem.add_development_dependency 'fakeredis', '~> 0.5'
   gem.add_development_dependency 'rake', '~> 11'

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -384,6 +384,13 @@ describe RedisSessionStore do
       it_should_behave_like 'serializer'
     end
 
+    context 'oj' do
+      let(:options) { { serializer: :oj } }
+      let(:encoded_data) { '{"some":"data"}' }
+
+      it_should_behave_like 'serializer'
+    end
+
     context 'hybrid' do
       let(:options) { { serializer: :hybrid } }
       let(:expected_encoding) { '{"some":"data"}' }


### PR DESCRIPTION
Hi
[Oj](https://github.com/ohler55/oj) is faster than built-in `json` gem to serialize to json.
Now we can select using built-in `:json` or optimized `:oj` optinally.