### PR TITLE
Decode sesssion with_indifferent_access if defined ActiveSupport

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
 
+Metrics/LineLength:
+  Max: 100
+
 Security/MarshalLoad:
   Enabled: false
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,4 +9,4 @@
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 108
+  Max: 110

--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ My::Application.config.session_store :redis_session_store, {
 
 **Note** The session will *always* be destroyed when it cannot be loaded.
 
+### Other notes
+
+It returns with_indifferent_access if ActiveSupport is defined
+
 ## Rails 2 Compatibility
 
 This gem is currently only compatible with Rails 3+.  If you need

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -13,6 +13,8 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
                               end
   end
 
+  USE_INDIFFERENT_ACCESS = defined?(ActiveSupport)
+
   # ==== Options
   # * +:key+ - Same as with the other cookie stores, key name
   # * +:redis+ - A hash with redis-specific options
@@ -92,10 +94,10 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
       session = {}
     end
 
-    [sid, session]
+    [sid, USE_INDIFFERENT_ACCESS ? session.with_indifferent_access : session]
   rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
     on_redis_down.call(e, env, sid) if on_redis_down
-    [generate_sid, {}]
+    [generate_sid, USE_INDIFFERENT_ACCESS ? {}.with_indifferent_access : {}]
   end
   alias find_session get_session
 


### PR DESCRIPTION
Inspire by https://github.com/roidrage/redis-session-store/issues/71

We are moving from active_record_store to redis_session_store 

but we already everywhere use key to access session, so we need this fix