### PR TITLE
Travis: jruby-9.2.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 cache: bundler
 rvm:
 - 2.3.1
-- jruby-9.1.17.0
+- jruby-9.2.0.0
 matrix:
   allow_failures:
-  - rvm: jruby-9.1.17.0
+  - rvm: jruby-9.2.0.0
 notifications:
   email: false
 deploy:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby.

http://jruby.org/2018/05/24/jruby-9-2-0-0.html