### PR TITLE
Fix Gemspec Deprecation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -7,6 +7,7 @@ Redis Session Store authors
 - Edwin Cruz
 - Gonçalo Silva
 - Ian C. Anderson
+- Jesse Doyle
 - Jorge Pardiñas
 - Justin McNally
 - Mathias Meyer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- Remove the `has_rdoc` parameter from the `.gemspec` file as it has been deprecated.
+
 ## [0.11.0] - 2018-08-13
 ### Changed
 - JRuby to jruby-9.2.0.0

--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |gem|
   gem.homepage = 'https://github.com/roidrage/redis-session-store'
   gem.license = 'MIT'
 
-  gem.has_rdoc = true
   gem.extra_rdoc_files = %w(LICENSE AUTHORS.md CONTRIBUTING.md)
 
   gem.files = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
* Remove the `has_rdoc` flag from the `.gemspec` file. Rubygems
  has deprecated this parameter and will be removing it in future
  versions.

I was seeing this error when installing my bundle:

```
Fetching git@github.com:roidrage/redis-session-store.git
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /home/travis/.rvm/gems/ruby-2.3.1/bundler/gems/redis-session-store-547d9908bae7/redis-session-store.gemspec:11.
```

SEE: https://blog.rubygems.org/2009/05/04/1.3.3-released.html