### PR TITLE
Remove upper dependency for actionpack

### DIFF
--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version = File.read('lib/redis-session-store.rb')
                     .match(/^  VERSION = '(.*)'/)[1]
 
-  gem.add_runtime_dependency 'actionpack', '>= 3', '< 6'
+  gem.add_runtime_dependency 'actionpack', '>= 3'
   gem.add_runtime_dependency 'redis', '>= 3', '< 5'
 
   gem.add_development_dependency 'fakeredis', '~> 0.5'


### PR DESCRIPTION
We are trying to test our application on rails 6.0.0.alpha but we can't install this because of the version lock
Probably this will be helpful that we can try and report any issues with edge rails