### PR TITLE
CI matrix: Add 2.6.3, update to jruby-9.2.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: ruby
-sudo: false
 cache: bundler
 rvm:
 - 2.3.8
 - 2.4.5
 - 2.5.3
-- 2.6.0
-- jruby-9.2.5.0
+- 2.6.1
+- jruby-9.2.6.0
 matrix:
   allow_failures:
-  - rvm: jruby-9.2.5.0
+  - rvm: jruby-9.2.6.0
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,13 @@ language: ruby
 cache: bundler
 rvm:
 - 2.3.8
-- 2.4.5
+- 2.4.6
 - 2.5.5
 - 2.6.2
-- jruby-9.2.6.0
+- jruby-9.2.7.0
 matrix:
   allow_failures:
-  - rvm: jruby-9.2.6.0
+  - rvm: jruby-9.2.7.0
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ rvm:
 - 2.3.8
 - 2.4.6
 - 2.5.5
-- 2.6.2
-- jruby-9.2.7.0
+- 2.6.3
+- jruby-9.2.8.0
 matrix:
   allow_failures:
-  - rvm: jruby-9.2.7.0
+  - rvm: jruby-9.2.8.0
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ cache: bundler
 rvm:
 - 2.3.8
 - 2.4.5
-- 2.5.3
-- 2.6.1
+- 2.5.5
+- 2.6.2
 - jruby-9.2.6.0
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.3.7
-- 2.4.4
-- 2.5.1
-- jruby-9.2.0.0
+- 2.3.8
+- 2.4.5
+- 2.5.3
+- 2.6.0
+- jruby-9.2.5.0
 matrix:
   allow_failures:
-  - rvm: jruby-9.2.0.0
+  - rvm: jruby-9.2.5.0
 notifications:
   email: false
 deploy:
@@ -19,4 +20,4 @@ deploy:
   on:
     tags: true
     repo: roidrage/redis-session-store
-    rvm: 2.3.1
+    rvm: 2.3.8

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -519,7 +519,7 @@ describe RedisSessionStore do
       end
 
       context 'when callable' do
-        let(:options) { { :"#{h}" => ->(*) { true } } }
+        let(:options) { { "#{h}": ->(*) { true } } }
 
         it 'does not explode at init' do
           expect { store }.to_not raise_error
@@ -527,7 +527,7 @@ describe RedisSessionStore do
       end
 
       context 'when not callable' do
-        let(:options) { { :"#{h}" => 'herpderp' } }
+        let(:options) { { "#{h}": 'herpderp' } }
 
         it 'explodes at init' do
           expect { store }.to raise_error(ArgumentError)


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.8.0**.

[JRuby 9.2.8.0 release blog post](https://www.jruby.org/2019/08/12/jruby-9-2-8-0.html)

---

Also: 

- fixes the `on` clause in the deploy section, so that it matches the 2.3 version used.
- drops the `sudo: false` directive, which is now unused