### PR TITLE
Release v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@
 
 ## [Unreleased]
 
+## [0.11.1] - 2019-08-22
+### Changed
 - Remove the `has_rdoc` parameter from the `.gemspec` file as it has been deprecated.
+- Actionpack to '>= 3', remove upper dependency
 
 ## [0.11.0] - 2018-08-13
 ### Changed
@@ -226,7 +229,8 @@
 ### Added
 - first working version
 
-[Unreleased]: https://github.com/roidrage/redis-session-store/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/roidrage/redis-session-store/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/roidrage/redis-session-store/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/roidrage/redis-session-store/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/roidrage/redis-session-store/compare/v0.9.2...v0.10.0
 [0.9.2]: https://github.com/roidrage/redis-session-store/compare/v0.9.1...v0.9.2

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -3,7 +3,7 @@ require 'redis'
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
 class RedisSessionStore < ActionDispatch::Session::AbstractStore
-  VERSION = '0.11.0'.freeze
+  VERSION = '0.11.1'.freeze
   # Rails 3.1 and beyond defines the constant elsewhere
   unless defined?(ENV_SESSION_OPTIONS_KEY)
     ENV_SESSION_OPTIONS_KEY = if Rack.release.split('.').first.to_i > 1


### PR DESCRIPTION
Proposing we release a v0.11.1 as it's important we have a release out without the `ActionPack <6` dependency upper bound now that Rails 6 has been released.

TL;DR Release a version that supports Rails 6.

Resolves https://github.com/roidrage/redis-session-store/issues/112