### PR TITLE
Update travis.yml Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,15 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.3.8
-- 2.4.6
-- 2.5.5
-- 2.6.3
+- 2.3
+- 2.4
+- 2.5
+- 2.6
+- ruby-head
 - jruby-9.2.8.0
 matrix:
   allow_failures:
+  - rvm: ruby-head
   - rvm: jruby-9.2.8.0
 notifications:
   email: false


### PR DESCRIPTION
Generalize the Ruby versions in our Travis CI config, so we're always testing against the latest, and add non-blocking `ruby-head`.