### PR TITLE
CI: Use jruby-9.2.9.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ rvm:
 - 2.5
 - 2.6
 - ruby-head
-- jruby-9.2.8.0
+- jruby-9.2.9.0
 matrix:
   allow_failures:
   - rvm: ruby-head
-  - rvm: jruby-9.2.8.0
+  - rvm: jruby-9.2.9.0
 notifications:
   email: false
 deploy:


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.9.0**.

[JRuby 9.2.9.0 release blog post](https://www.jruby.org/2019/10/30/jruby-9-2-9-0.html)