### PR TITLE
Fix rubocop warnings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,17 +4,17 @@ AllCops:
     - 'Rakefile'
     - 'vendor/**/*'
 
-FileName:
+Naming/FileName:
   Enabled: false
 
-DoubleNegation:
+Style/DoubleNegation:
   Enabled: false
 
 Metrics/BlockLength:
   Exclude:
     - 'spec/**/*.rb'
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 100
 
 Metrics/ClassLength:


### PR DESCRIPTION
This fixes following rubocop warnings:

```
/home/y-yagi/src/github.com/y-yagi/redis-session-store/.rubocop.yml: Warning: no department given for FileName.
/home/y-yagi/src/github.com/y-yagi/redis-session-store/.rubocop.yml: Warning: no department given for DoubleNegation.
.rubocop.yml: Metrics/LineLength has the wrong namespace - should be Layout
```