### PR TITLE
Update key existence check to use newer #exists? if available

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -22,3 +22,4 @@ Redis Session Store authors
 - Sergey Nebolsin
 - Anton Kolodii
 - Peter Karman
+- Zach Margolis

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- Silence deprecation warning when using with redis gem v4.2+
+
 ## [0.11.1] - 2019-08-22
 ### Changed
 - Remove the `has_rdoc` parameter from the `.gemspec` file as it has been deprecated.

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -67,12 +67,22 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
 
     !!(
       value && !value.empty? &&
-      redis.exists(prefixed(value))
+      key_exists?(value)
     )
   rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
     on_redis_down.call(e, env, value) if on_redis_down
 
     true
+  end
+
+  def key_exists?(value)
+    if redis.respond_to?(:exists?)
+      # added in redis gem v4.2
+      redis.exists?(prefixed(value))
+    else
+      # older method, will return an integer starting in redis gem v4.3
+      redis.exists(prefixed(value))
+    end
   end
 
   def verify_handlers!


### PR DESCRIPTION
- Silences deprecation warning starting in redis gem v4.2

In upgrading the redis gem in our project, we get this deprecation warning:

```
`Redis#exists(key)` will return an Integer in redis-rb 4.3. `exists?` returns a boolean, you should use it instead. To opt-in to the new behavior now you can set Redis.exists_returns_integer =  true. To disable this message and keep the current (boolean) behaviour of 'exists' you can set `Redis.exists_returns_integer = false`, but this option will be removed in 5.0. (/.../ruby/gems/2.6.0/gems/redis-session-store-0.11.1/lib/redis-session-store.rb:70:in `session_exists?')
```