### PR TITLE
Make get_session/set_session/destroy_session public

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -54,6 +54,33 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
 
   attr_accessor :on_redis_down, :on_session_load_error
 
+  def get_session(env, sid)
+    sid && (session = load_session_from_redis(sid)) ? [sid, session] : session_default_values
+  rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
+    on_redis_down.call(e, env, sid) if on_redis_down
+    session_default_values
+  end
+  alias find_session get_session
+
+  def set_session(env, sid, session_data, options = nil)
+    expiry = get_expiry(env, options)
+    if expiry
+      redis.setex(prefixed(sid), expiry, encode(session_data))
+    else
+      redis.set(prefixed(sid), encode(session_data))
+    end
+    sid
+  rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
+    on_redis_down.call(e, env, sid) if on_redis_down
+    false
+  end
+  alias write_session set_session
+
+  def destroy_session(env, sid, options)
+    destroy_session_from_sid(sid, (options || {}).to_hash.merge(env: env))
+  end
+  alias delete_session destroy_session
+
   private
 
   attr_reader :redis, :key, :default_options, :serializer
@@ -101,14 +128,6 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
     [generate_sid, USE_INDIFFERENT_ACCESS ? {}.with_indifferent_access : {}]
   end
 
-  def get_session(env, sid)
-    sid && (session = load_session_from_redis(sid)) ? [sid, session] : session_default_values
-  rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
-    on_redis_down.call(e, env, sid) if on_redis_down
-    session_default_values
-  end
-  alias find_session get_session
-
   def load_session_from_redis(sid)
     data = redis.get(prefixed(sid))
     begin
@@ -125,20 +144,6 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
     USE_INDIFFERENT_ACCESS ? session.with_indifferent_access : session
   end
 
-  def set_session(env, sid, session_data, options = nil)
-    expiry = get_expiry(env, options)
-    if expiry
-      redis.setex(prefixed(sid), expiry, encode(session_data))
-    else
-      redis.set(prefixed(sid), encode(session_data))
-    end
-    sid
-  rescue Errno::ECONNREFUSED, Redis::CannotConnectError => e
-    on_redis_down.call(e, env, sid) if on_redis_down
-    false
-  end
-  alias write_session set_session
-
   def get_expiry(env, options)
     session_storage_options = options || env.fetch(ENV_SESSION_OPTIONS_KEY, {})
     session_storage_options[:ttl] || session_storage_options[:expire_after]
@@ -147,11 +152,6 @@ class RedisSessionStore < ActionDispatch::Session::AbstractStore
   def encode(session_data)
     serializer.dump(session_data)
   end
-
-  def destroy_session(env, sid, options)
-    destroy_session_from_sid(sid, (options || {}).to_hash.merge(env: env))
-  end
-  alias delete_session destroy_session
 
   def destroy(env)
     if env['rack.request.cookie_hash'] &&

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -164,7 +164,7 @@ describe RedisSessionStore do
 
     context 'when successfully persisting the session' do
       it 'returns the session id' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
+        expect(store.set_session(env, session_id, session_data, options))
           .to eq(session_id)
       end
     end
@@ -175,7 +175,7 @@ describe RedisSessionStore do
       end
 
       it 'returns false' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
+        expect(store.set_session(env, session_id, session_data, options))
           .to eq(false)
       end
     end
@@ -184,7 +184,7 @@ describe RedisSessionStore do
       let(:options) { {} }
 
       it 'sets the session value without expiry' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
+        expect(store.set_session(env, session_id, session_data, options))
           .to eq(session_id)
       end
     end
@@ -196,12 +196,12 @@ describe RedisSessionStore do
       end
 
       it 'returns false' do
-        expect(store.send(:set_session, env, session_id, session_data, options))
+        expect(store.set_session(env, session_id, session_data, options))
           .to eq(false)
       end
 
       it 'calls the on_redis_down handler' do
-        store.send(:set_session, env, session_id, session_data, options)
+        store.set_session(env, session_id, session_data, options)
         expect(@redis_down_handled).to eq(true)
       end
 
@@ -210,7 +210,7 @@ describe RedisSessionStore do
 
         it 'explodes' do
           expect do
-            store.send(:set_session, env, session_id, session_data, options)
+            store.set_session(env, session_id, session_data, options)
           end.to raise_error(Redis::CannotConnectError)
         end
       end
@@ -287,7 +287,7 @@ describe RedisSessionStore do
       allow(store).to receive(:generate_sid).and_return(fake_key)
       expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key}")
 
-      store.send(:get_session, double('env'), fake_key)
+      store.get_session(double('env'), fake_key)
     end
 
     context 'when redis is down' do
@@ -297,12 +297,12 @@ describe RedisSessionStore do
       end
 
       it 'returns an empty session hash' do
-        expect(store.send(:get_session, double('env'), fake_key).last)
+        expect(store.get_session(double('env'), fake_key).last)
           .to eq({})
       end
 
       it 'returns a newly generated sid' do
-        expect(store.send(:get_session, double('env'), fake_key).first)
+        expect(store.get_session(double('env'), fake_key).first)
           .to eq('foop')
       end
 
@@ -311,7 +311,7 @@ describe RedisSessionStore do
 
         it 'explodes' do
           expect do
-            store.send(:get_session, double('env'), fake_key)
+            store.get_session(double('env'), fake_key)
           end.to raise_error(Redis::CannotConnectError)
         end
       end
@@ -365,7 +365,7 @@ describe RedisSessionStore do
         sid = store.send(:generate_sid)
         expect(redis).to receive(:del).with("#{options[:key_prefix]}#{sid}")
 
-        store.send(:destroy_session, {}, sid, nil)
+        store.destroy_session({}, sid, nil)
       end
     end
   end
@@ -386,11 +386,11 @@ describe RedisSessionStore do
     shared_examples_for 'serializer' do
       it 'encodes correctly' do
         expect(redis).to receive(:set).with('12345', expected_encoding)
-        store.send(:set_session, env, session_id, session_data, options)
+        store.set_session(env, session_id, session_data, options)
       end
 
       it 'decodes correctly' do
-        expect(store.send(:get_session, env, session_id))
+        expect(store.get_session(env, session_id))
           .to eq([session_id, session_data])
       end
     end
@@ -542,10 +542,10 @@ describe RedisSessionStore do
       sid = 1234
       allow(store).to receive(:redis).and_return(Redis.new)
       data1 = { 'foo' => 'bar' }
-      store.send(:set_session, env, sid, data1)
+      store.set_session(env, sid, data1)
       data2 = { 'baz' => 'wat' }
-      store.send(:set_session, env, sid, data2)
-      _, session = store.send(:get_session, env, sid)
+      store.set_session(env, sid, data2)
+      _, session = store.get_session(env, sid)
       expect(session).to eq(data2)
     end
 
@@ -554,10 +554,10 @@ describe RedisSessionStore do
       sid = 1234
       allow(store).to receive(:redis).and_return(Redis.new)
       data1 = { 'foo' => 'bar' }
-      store.send(:set_session, env, sid, data1)
+      store.set_session(env, sid, data1)
       data2 = { 'baz' => 'wat' }
-      store.send(:set_session, env, sid, data2)
-      _, session = store.send(:get_session, env, sid)
+      store.set_session(env, sid, data2)
+      _, session = store.get_session(env, sid)
       expect(session).to eq(data2)
     end
   end


### PR DESCRIPTION
Inspired by https://github.com/roidrage/redis-session-store/pull/83 

But also with Rails 6.1.0.rc1 there is  error 
NoMethodError (private method delete_session' called for #RedisSessionStore:0x0000555c9eed60c0):`