### PR TITLE
CI: Use JRuby 9.2.19.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ rvm:
 - 2.5
 - 2.6
 - ruby-head
-- jruby-9.2.12.0
+- jruby-9.2.15.0
 matrix:
   allow_failures:
   - rvm: ruby-head
-  - rvm: jruby-9.2.12.0
+  - rvm: jruby-9.2.15.0
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,13 @@ rvm:
 - 2.5
 - 2.6
 - ruby-head
-- jruby-9.2.16.0
 matrix:
+  include:
+    - rvm: jruby-9.2.18.0
+      name: "Latest JRuby"
   allow_failures:
-  - rvm: ruby-head
-  - rvm: jruby-9.2.16.0
+    - rvm: ruby-head
+    - name: "Latest JRuby"
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ rvm:
 - 2.5
 - 2.6
 - ruby-head
-- jruby-9.2.15.0
+- jruby-9.2.16.0
 matrix:
   allow_failures:
   - rvm: ruby-head
-  - rvm: jruby-9.2.15.0
+  - rvm: jruby-9.2.16.0
 notifications:
   email: false
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ rvm:
 - ruby-head
 matrix:
   include:
-    - rvm: jruby-9.2.18.0
+    - rvm: jruby-9.2.19.0
       name: "Latest JRuby"
   allow_failures:
     - rvm: ruby-head


### PR DESCRIPTION
This PR updates the CI matrix to use latest JRuby, **9.2.19.0**.

[JRuby 9.2.19.0 release blog post](https://www.jruby.org/2021/06/15/jruby-9-2-19-0.html)