### PR TITLE
Make actionpack dependency more than or equal to 6

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -24,3 +24,4 @@ Redis Session Store authors
 - Peter Karman
 - Zach Margolis
 - Zachary Belzer
+- Yutaka Kamei

--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version = File.read('lib/redis-session-store.rb')
                     .match(/^  VERSION = '(.*)'/)[1]
 
-  gem.add_runtime_dependency 'actionpack', '>= 3', '< 8'
+  gem.add_runtime_dependency 'actionpack', '>= 6', '< 8'
   gem.add_runtime_dependency 'redis', '>= 3', '< 5'
 
   gem.add_development_dependency 'fakeredis', '~> 0.8'


### PR DESCRIPTION
Thanks to #125, `RedisSessionStore` inherits `AbstractSecureStore`, but it was introduced in Rails 6 https://github.com/rails/rails/commit/ad2da1ad82742354a73cf30be658574d9bd567f0. So, I think `redis-session-store` should narrow the constraint of `actionpack` more than or equal to 6.

