### PR TITLE
CI: Use latest checkout action

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -30,7 +30,7 @@ jobs:
           - jruby-head
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
This PR updates the `actions/checkout` to v3.