### PR TITLE
support for redis-rb v5

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -40,11 +40,10 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   def initialize(app, options = {})
     super
 
-    redis_options = options[:redis] || {}
-
     @default_options[:namespace] = 'rack:session'
-    @default_options.merge!(redis_options)
-    @redis = redis_options[:client] || Redis.new(redis_options)
+    @default_options.merge!(options[:redis] || {})
+    init_options = options[:redis]&.reject { |k, _v| %i[expire_after key_prefix].include?(k) } || {}
+    @redis = init_options[:client] || Redis.new(init_options)
     @on_redis_down = options[:on_redis_down]
     @serializer = determine_serializer(options[:serializer])
     @on_session_load_error = options[:on_session_load_error]

--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
                     .match(/^  VERSION = '(.*)'/)[1]
 
   gem.add_runtime_dependency 'actionpack', '>= 6', '< 8'
-  gem.add_runtime_dependency 'redis', '>= 3', '< 5'
+  gem.add_runtime_dependency 'redis', '>= 3', '< 6'
 
   gem.add_development_dependency 'fakeredis', '~> 0.8'
   gem.add_development_dependency 'rake', '~> 13'


### PR DESCRIPTION
Add support for `redis-rb` v5.

Passes all cops and specs.

The primary consideration for v5 is that we cannot pass invalid config options to the Redis gem going forward. This means that `:expire_after` and `:key_prefix` need to be removed from the options hash before it is passed to `Redis.new`.

I apologize for the janky code and seemingly pointless variable rename. The project is configured to accept 10 lines per method and 100 characters per line. The method was 9 lines when I got to it, and line 45 is exactly 100 characters long.

Nobody is asking for my opinion on these constraints, so I'll leave it to you if you want to guess. 😉 

Closes #135