### PR TITLE
Always use `with_indifferent_access`

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -1,4 +1,5 @@
 require 'redis'
+require 'active_support/core_ext/hash/indifferent_access'
 
 # Redis session storage for Rails, and for Rails only. Derived from
 # the MemCacheStore code, simply dropping in Redis instead.
@@ -13,7 +14,6 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
                               end
   end
 
-  USE_INDIFFERENT_ACCESS = defined?(ActiveSupport).freeze
   # ==== Options
   # * +:key+ - Same as with the other cookie stores, key name
   # * +:redis+ - A hash with redis-specific options
@@ -96,7 +96,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   end
 
   def session_default_values
-    [generate_sid, USE_INDIFFERENT_ACCESS ? {}.with_indifferent_access : {}]
+    [generate_sid, {}.with_indifferent_access]
   end
 
   def get_session(env, sid)
@@ -120,7 +120,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
 
   def decode(data)
     session = serializer.load(data)
-    USE_INDIFFERENT_ACCESS ? session.with_indifferent_access : session
+    session.with_indifferent_access
   end
 
   def set_session(env, sid, session_data, options = nil)


### PR DESCRIPTION
In a typical rails app the probability of `ActiveSupport` being already present is almost certain.
Do we need additional checks?

Formally this is a major change, since someone may have hacks in place to avoid `with_indifferent_access` (like requiring us before rails) and may require some workaround like
```ruby
class DifferentAccessRedisSessionStore < RedisSessionStore
  def session_default_values
    [generate_sid, {}]
  end

  def decode(data)
    serializer.load(data)
  end
end

Rails.application.config.session_store(DifferentAccessRedisSessionStore, redis: ...)
```