### PR TITLE
Allow actionpack 5.2.4.1

### DIFF
--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version = File.read('lib/redis-session-store.rb')
                     .match(/^  VERSION = '(.*)'/)[1]
 
-  gem.add_runtime_dependency 'actionpack', '>= 6', '< 8'
+  gem.add_runtime_dependency 'actionpack', '>= 5.2.4.1', '< 8'
   gem.add_runtime_dependency 'redis', '>= 3', '< 6'
 
   gem.add_development_dependency 'fakeredis', '~> 0.8'


### PR DESCRIPTION
#129 set the required actionpack version to `> 6` to pick up the addition of `AbstractSecureStore`.

The change to add AbstractSecureStore was backported to [actionpack 5.2.4.1](https://github.com/rails/rails/blob/5-2-stable/actionpack/CHANGELOG.md#rails-5241-december-18-2019) as https://github.com/rails/rails/commit/2a52a38cb51b65d71cf91fc960777213cf96f962. This PR loosens the constraint to `>= 5.2.4.1`