### PR TITLE
Reduce exists command by loading from private_id first

### DIFF
--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -120,9 +120,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
   def load_session_with_fallback(sid)
     return nil if private_session_id?(sid.public_id)
 
-    load_session_from_redis(
-      key_exists?(sid.private_id) ? sid.private_id : sid.public_id
-    )
+    load_session_from_redis(sid.private_id) || load_session_from_redis(sid.public_id)
   end
 
   def load_session_from_redis(sid)

--- a/spec/redis_session_store_spec.rb
+++ b/spec/redis_session_store_spec.rb
@@ -318,25 +318,26 @@ describe RedisSessionStore do
 
     context 'when redis is up' do
       let(:redis) { double('redis') }
-      let(:private_exists) { true }
+      let(:private_value) { Marshal.dump('foo') }
 
       before do
         allow(store).to receive(:redis).and_return(redis)
-        allow(redis).to receive(:exists)
+        allow(redis).to receive(:get)
           .with("#{options[:key_prefix]}#{session_id.private_id}")
-          .and_return(private_exists)
+          .and_return(private_value)
       end
 
       context 'when session private id exists in redis' do
         it 'retrieves the prefixed private id from redis' do
           expect(redis).to receive(:get).with("#{options[:key_prefix]}#{session_id.private_id}")
+          expect(redis).not_to receive(:get).with("#{options[:key_prefix]}#{fake_key}")
 
           store.send(:get_session, double('env'), session_id)
         end
       end
 
       context 'when session private id not found in redis' do
-        let(:private_exists) { false }
+        let(:private_value) { nil }
 
         it 'retrieves the prefixed public id from redis' do
           expect(redis).to receive(:get).with("#{options[:key_prefix]}#{fake_key}")


### PR DESCRIPTION
The current redis-session-store has been implemented to throw the exists command to redis twice.
https://github.com/roidrage/redis-session-store/blob/21c576d5460f38ee781037114ec22f354c453828/lib/redis-session-store.rb#L68
https://github.com/roidrage/redis-session-store/blob/21c576d5460f38ee781037114ec22f354c453828/lib/redis-session-store.rb#L124

With this PR implementation, a session that has not been migrated to private_id will throw get commands to private_id and public_id twice. But migrated session will only get once, which I think is more efficient.