### PR TITLE
Remove ttl from redis initialization options for redis-rb v5

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,6 +1,7 @@
 Redis Session Store authors
 ===========================
 
+- Atsushi Tatsuma
 - Ben Marini
 - Bill Ruddock
 - Dan Buch

--- a/lib/redis-session-store.rb
+++ b/lib/redis-session-store.rb
@@ -42,7 +42,7 @@ class RedisSessionStore < ActionDispatch::Session::AbstractSecureStore
 
     @default_options[:namespace] = 'rack:session'
     @default_options.merge!(options[:redis] || {})
-    init_options = options[:redis]&.reject { |k, _v| %i[expire_after key_prefix].include?(k) } || {}
+    init_options = options[:redis]&.reject { |k, _v| %i[expire_after ttl key_prefix].include?(k) } || {}
     @redis = init_options[:client] || Redis.new(init_options)
     @on_redis_down = options[:on_redis_down]
     @serializer = determine_serializer(options[:serializer])


### PR DESCRIPTION
redis-rb v5 depends on redis_client, and redis_client's initialize method does not have `ttl` keyword argument, so specifying the ttl option in redis-session-store will cause an ArgumentError when starting Rails. This problem can be solved by not giving the ttl option to Redis.new, as in https://github.com/roidrage/redis-session-store/pull/137.

```sh
$ bin/rails s
=> Booting Puma
=> Rails 7.0.4.3 application starting in development
=> Run `bin/rails server --help` for more startup options
Exiting
/home/foo/.anyenv/envs/rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/redis-client-0.14.1/lib/redis_client/config.rb:21:in `initialize': unknown keyword: :ttl (ArgumentError)
	from /home/foo/.anyenv/envs/rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/redis-client-0.14.1/lib/redis_client/config.rb:184:in `initialize'
	from /home/foo/.anyenv/envs/rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/redis-client-0.14.1/lib/redis_client.rb:143:in `new'
	from /home/foo/.anyenv/envs/rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/redis-client-0.14.1/lib/redis_client.rb:143:in `config'
	from /home/foo/.anyenv/envs/rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/redis-5.0.6/lib/redis/client.rb:23:in `config'
	from /home/foo/.anyenv/envs/rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/redis-5.0.6/lib/redis.rb:157:in `initialize_client'
	from /home/foo/.anyenv/envs/rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/redis-5.0.6/lib/redis.rb:73:in `initialize'
	from /home/foo/.anyenv/envs/rbenv/versions/3.1.3/lib/ruby/gems/3.1.0/gems/redis-session-store-0.11.5/lib/redis-session-store.rb:46:in `new'
...
```