### PR TITLE
Support Rails 8

### DIFF
--- a/redis-session-store.gemspec
+++ b/redis-session-store.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version = File.read('lib/redis-session-store.rb')
                     .match(/^  VERSION = '(.*)'/)[1]
 
-  gem.add_runtime_dependency 'actionpack', '>= 5.2.4.1', '< 8'
+  gem.add_runtime_dependency 'actionpack', '>= 5.2.4.1', '< 9'
   gem.add_runtime_dependency 'redis', '>= 3', '< 6'
 
   gem.add_development_dependency 'fakeredis', '~> 0.8'


### PR DESCRIPTION
Specifying a `< 8` for `actionpack`(`rails`) means that this gem is incompatible with Rails 8 for now.

The _real_ problem here is that `0.7.0` had *no dependency versions defined* so any app attempting to upgrade without specifying a min version of this gem will get *downgraded to `0.7.0`*:
https://github.com/roidrage/redis-session-store/blob/v0.7.0/redis-session-store.gemspec#L21

That causes this exception for us at runtime:
```
/redis-session-store-0.7.0/lib/redis-session-store.rb:10:in `<class:RedisSessionStore>': uninitialized constant Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY (NameError)

    ENV_SESSION_OPTIONS_KEY = Rack::Session::Abstract::ENV_SESSION_OPTIONS_KEY
```

This was similarly encountered for Rails 6 in https://github.com/roidrage/redis-session-store/pull/110